### PR TITLE
Fix:fatal error: unexpected signal during runtime execution

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -6,8 +6,6 @@ package zbar
 // #include <zbar.h>
 import "C"
 
-import "runtime"
-
 type Scanner struct {
 	scanner *C.zbar_image_scanner_t
 }
@@ -16,7 +14,7 @@ func NewScanner() *Scanner {
 	r := &Scanner{
 		scanner: C.zbar_image_scanner_create(),
 	}
-	runtime.SetFinalizer(r, (*Scanner).Destroy)
+	// runtime.SetFinalizer(r, (*Scanner).Destroy)
 	return r
 }
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -26,6 +26,7 @@ func TestBarcode(t *testing.T) {
 	s.SetConfig(0, CFG_ENABLE, 1)
 
 	s.Scan(img)
+	defer s.Destroy()
 
 	img.First().Each(func(str string) {
 		fmt.Println(str)
@@ -50,6 +51,7 @@ func TestQRCode(t *testing.T) {
 	s := NewScanner()
 	s.SetConfig(0, CFG_ENABLE, 1)
 	s.Scan(img)
+	defer s.Destroy()
 
 	img.First().Each(func(str string) {
 		// Charset decoding
@@ -77,6 +79,7 @@ func TestPhoto(t *testing.T) {
 	s := NewScanner()
 	s.SetConfig(0, CFG_ENABLE, 1)
 	s.Scan(img)
+	defer s.Destroy()
 
 	img.First().Each(func(str string) {
 		// Charset decoding


### PR DESCRIPTION
got error at Jmeter testing 

fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x50b182c]

runtime stack:
runtime.throw(0x47c83ec, 0x2a)
	/usr/local/go/src/runtime/panic.go:617 +0x72
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:374 +0x4a9

goroutine 513 [syscall]:
runtime.cgocall(0x4630ec0, 0xc00092d970, 0x0)
	/usr/local/go/src/runtime/cgocall.go:128 +0x5b fp=0xc00092d940 sp=0xc00092d908 pc=0x4004eeb
meipian.cn/zbar/vendor/github.com/PeterCxy/gozbar._Cfunc_zbar_scan_image(0x5607640, 0x5748df0, 0x0)
	_cgo_gotypes.go:235 +0x4d fp=0xc00092d970 sp=0xc00092d940 pc=0x46114ad
meipian.cn/zbar/vendor/github.com/PeterCxy/gozbar.(*Scanner).Scan.func1(0xc0002341b8, 0xc0006687a0, 0x0)
	.../zbar/vendor/github.com/PeterCxy/gozbar/scanner.go:36 +0xa4 fp=0xc00092d9b8 sp=0xc00092d970 pc=0x46122a4
meipian.cn/zbar/vendor/github.com/PeterCxy/gozbar.(*Scanner).Scan(0xc0002341b8, 0xc0006687a0, 0x1)
	.../zbar/vendor/github.com/PeterCxy/gozbar/scanner.go:36 +0x35 fp=0xc00092d9e0 sp=0xc00092d9b8 pc=0x4611ba5
meipian.cn/zbar/service.QrCode(0xc000092c60, 0x5d, 0x0, 0x0)
	.../zbar/service/qrcode.go:66 +0x549 fp=0xc00092da88 sp=0xc00092d9e0 pc=0x4612a69
meipian.cn/zbar/controller.QrCode(0xc00031def0)